### PR TITLE
Rename lifecycle rules and split tag lifecycle filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -91,13 +90,14 @@ Available targets:
 | force_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | string | `false` | no |
 | glacier_transition_days | Number of days after which to move the data to the glacier storage tier | string | `60` | no |
 | kms_master_key_id | The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse_algorithm is aws:kms | string | `` | no |
+| lifecycle_prefix | (Optional) Prefix filter. Used to manage object lifecycle events. | string | `` | no |
 | lifecycle_rule_enabled | (Optional) enable lifecycle events on this bucket | string | `true` | no |
+| lifecycle_tags | (Optional) Tags filter. Used to manage object lifecycle events. | map | `<map>` | no |
 | name | Name  (e.g. `app` or `db`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | noncurrent_version_expiration_days | (Optional) Specifies when noncurrent object versions expire. | string | `90` | no |
 | noncurrent_version_transition_days | (Optional) Specifies when noncurrent object versions transitions | string | `30` | no |
 | policy | A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. | string | `` | no |
-| prefix | (Optional) Key prefix. Used to manage object lifecycle events. | string | `` | no |
 | region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | string | `` | no |
 | sse_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | string | `AES256` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
@@ -199,7 +199,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
-|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] |
-|---|---|---|
+|  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] | [![Gonzalo Peci][pecigonzalo_avatar]][pecigonzalo_homepage]<br/>[Gonzalo Peci][pecigonzalo_homepage] |
+|---|---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://github.com/osterman.png?size=150
@@ -263,6 +263,8 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [aknysh_avatar]: https://github.com/aknysh.png?size=150
   [SweetOps_homepage]: https://github.com/SweetOps
   [SweetOps_avatar]: https://github.com/SweetOps.png?size=150
+  [pecigonzalo_homepage]: https://github.com/pecigonzalo
+  [pecigonzalo_avatar]: https://github.com/pecigonzalo.png?size=150
 
 
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| acl | (Optional) The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services | string | `log-delivery-write` | no |
+| acl | The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services | string | `log-delivery-write` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | list | `<list>` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enabled | Set to `false` to prevent the module from creating any resources | string | `true` | no |
@@ -90,20 +90,20 @@ Available targets:
 | force_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | string | `false` | no |
 | glacier_transition_days | Number of days after which to move the data to the glacier storage tier | string | `60` | no |
 | kms_master_key_id | The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse_algorithm is aws:kms | string | `` | no |
-| lifecycle_prefix | (Optional) Prefix filter. Used to manage object lifecycle events. | string | `` | no |
-| lifecycle_rule_enabled | (Optional) enable lifecycle events on this bucket | string | `true` | no |
-| lifecycle_tags | (Optional) Tags filter. Used to manage object lifecycle events. | map | `<map>` | no |
+| lifecycle_prefix | Prefix filter. Used to manage object lifecycle events. | string | `` | no |
+| lifecycle_rule_enabled | Enable lifecycle events on this bucket | string | `true` | no |
+| lifecycle_tags | Tags filter. Used to manage object lifecycle events. | map | `<map>` | no |
 | name | Name  (e.g. `app` or `db`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
-| noncurrent_version_expiration_days | (Optional) Specifies when noncurrent object versions expire. | string | `90` | no |
-| noncurrent_version_transition_days | (Optional) Specifies when noncurrent object versions transitions | string | `30` | no |
+| noncurrent_version_expiration_days | Specifies when noncurrent object versions expire. | string | `90` | no |
+| noncurrent_version_transition_days | Specifies when noncurrent object versions transitions | string | `30` | no |
 | policy | A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. | string | `` | no |
-| region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | string | `` | no |
+| region | If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | string | `` | no |
 | sse_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | string | `AES256` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | standard_transition_days | Number of days to persist in the standard storage tier before moving to the infrequent access tier | string | `30` | no |
 | tags | Additional tags (e.g. map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
-| versioning_enabled | (Optional) A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket. | string | `false` | no |
+| versioning_enabled | A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket. | string | `false` | no |
 
 ## Outputs
 

--- a/README.yaml
+++ b/README.yaml
@@ -103,3 +103,5 @@ contributors:
     github: "aknysh"
   - name: "Vladimir"
     github: "SweetOps"
+  - name: "Gonzalo Peci"
+    github: "pecigonzalo"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -2,7 +2,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| acl | (Optional) The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services | string | `log-delivery-write` | no |
+| acl | The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services | string | `log-delivery-write` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | list | `<list>` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enabled | Set to `false` to prevent the module from creating any resources | string | `true` | no |
@@ -10,20 +10,20 @@
 | force_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | string | `false` | no |
 | glacier_transition_days | Number of days after which to move the data to the glacier storage tier | string | `60` | no |
 | kms_master_key_id | The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse_algorithm is aws:kms | string | `` | no |
-| lifecycle_prefix | (Optional) Prefix filter. Used to manage object lifecycle events. | string | `` | no |
-| lifecycle_rule_enabled | (Optional) enable lifecycle events on this bucket | string | `true` | no |
-| lifecycle_tags | (Optional) Tags filter. Used to manage object lifecycle events. | map | `<map>` | no |
+| lifecycle_prefix | Prefix filter. Used to manage object lifecycle events. | string | `` | no |
+| lifecycle_rule_enabled | Enable lifecycle events on this bucket | string | `true` | no |
+| lifecycle_tags | Tags filter. Used to manage object lifecycle events. | map | `<map>` | no |
 | name | Name  (e.g. `app` or `db`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
-| noncurrent_version_expiration_days | (Optional) Specifies when noncurrent object versions expire. | string | `90` | no |
-| noncurrent_version_transition_days | (Optional) Specifies when noncurrent object versions transitions | string | `30` | no |
+| noncurrent_version_expiration_days | Specifies when noncurrent object versions expire. | string | `90` | no |
+| noncurrent_version_transition_days | Specifies when noncurrent object versions transitions | string | `30` | no |
 | policy | A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. | string | `` | no |
-| region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | string | `` | no |
+| region | If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | string | `` | no |
 | sse_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | string | `AES256` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | standard_transition_days | Number of days to persist in the standard storage tier before moving to the infrequent access tier | string | `30` | no |
 | tags | Additional tags (e.g. map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
-| versioning_enabled | (Optional) A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket. | string | `false` | no |
+| versioning_enabled | A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket. | string | `false` | no |
 
 ## Outputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -11,13 +10,14 @@
 | force_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | string | `false` | no |
 | glacier_transition_days | Number of days after which to move the data to the glacier storage tier | string | `60` | no |
 | kms_master_key_id | The AWS KMS master key ID used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse_algorithm is aws:kms | string | `` | no |
+| lifecycle_prefix | (Optional) Prefix filter. Used to manage object lifecycle events. | string | `` | no |
 | lifecycle_rule_enabled | (Optional) enable lifecycle events on this bucket | string | `true` | no |
+| lifecycle_tags | (Optional) Tags filter. Used to manage object lifecycle events. | map | `<map>` | no |
 | name | Name  (e.g. `app` or `db`) | string | - | yes |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | noncurrent_version_expiration_days | (Optional) Specifies when noncurrent object versions expire. | string | `90` | no |
 | noncurrent_version_transition_days | (Optional) Specifies when noncurrent object versions transitions | string | `30` | no |
 | policy | A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. | string | `` | no |
-| prefix | (Optional) Key prefix. Used to manage object lifecycle events. | string | `` | no |
 | region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | string | `` | no |
 | sse_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | string | `AES256` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -25,8 +25,8 @@ resource "aws_s3_bucket" "default" {
     id      = "${module.default_label.id}"
     enabled = "${var.lifecycle_rule_enabled}"
 
-    prefix = "${var.prefix}"
-    tags   = "${module.default_label.tags}"
+    prefix = "${var.lifecycle_prefix}"
+    tags   = "${var.lifecycle_tags}"
 
     noncurrent_version_expiration {
       days = "${var.noncurrent_version_expiration_days}"

--- a/output.tf
+++ b/output.tf
@@ -14,7 +14,7 @@ output "bucket_arn" {
 }
 
 output "prefix" {
-  value       = "${var.prefix}"
+  value       = "${var.lifecycle_prefix}"
   description = "Prefix configured for lifecycle rules"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "tags" {
 }
 
 variable "acl" {
-  description = "(Optional) The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services"
+  description = "The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services"
   default     = "log-delivery-write"
 }
 
@@ -42,17 +42,17 @@ variable "policy" {
 }
 
 variable "lifecycle_prefix" {
-  description = "(Optional) Prefix filter. Used to manage object lifecycle events."
+  description = "Prefix filter. Used to manage object lifecycle events."
   default     = ""
 }
 
 variable "lifecycle_tags" {
-  description = "(Optional) Tags filter. Used to manage object lifecycle events."
+  description = "Tags filter. Used to manage object lifecycle events."
   default     = {}
 }
 
 variable "region" {
-  description = "(Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee."
+  description = "If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee."
   default     = ""
 }
 
@@ -62,22 +62,22 @@ variable "force_destroy" {
 }
 
 variable "lifecycle_rule_enabled" {
-  description = "(Optional) enable lifecycle events on this bucket"
+  description = "Enable lifecycle events on this bucket"
   default     = "true"
 }
 
 variable "versioning_enabled" {
-  description = "(Optional) A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket."
+  description = "A state of versioning. Versioning is a means of keeping multiple variants of an object in the same bucket."
   default     = "false"
 }
 
 variable "noncurrent_version_expiration_days" {
-  description = "(Optional) Specifies when noncurrent object versions expire."
+  description = "Specifies when noncurrent object versions expire."
   default     = "90"
 }
 
 variable "noncurrent_version_transition_days" {
-  description = "(Optional) Specifies when noncurrent object versions transitions"
+  description = "Specifies when noncurrent object versions transitions"
   default     = "30"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -41,9 +41,14 @@ variable "policy" {
   default     = ""
 }
 
-variable "prefix" {
-  description = "(Optional) Key prefix. Used to manage object lifecycle events."
+variable "lifecycle_prefix" {
+  description = "(Optional) Prefix filter. Used to manage object lifecycle events."
   default     = ""
+}
+
+variable "lifecycle_tags" {
+  description = "(Optional) Tags filter. Used to manage object lifecycle events."
+  default     = {}
 }
 
 variable "region" {


### PR DESCRIPTION
The `tags` generated by the label module were propagated to the S3 Lifecycle filters, this is in general not desired, as it means the lifecycle only applies to objects with those tags.

Console help message for the setting:
> Add filter to limit scope to prefix/tags

Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlifecycle.html

This adds a new var `lifecycle_tags` which is a map of the tags to apply to the lifecycle rule