### PR TITLE
Add variable to disable default cloud posse tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -63,5 +63,5 @@ resource "aws_s3_bucket" "default" {
     }
   }
 
-  tags = module.default_label.tags
+  tags = var.cloud_posse_tags ? module.default_label.tags : var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "tags" {
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
 
+variable "cloud_posse_tags" {
+  type        = bool
+  default     = true
+  description = "Specifies whether tags should be enahnced with Cloud Posse defaults"
+}
+
 variable "acl" {
   type        = string
   description = "The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services"


### PR DESCRIPTION
Thanks for this open source module, I'm planning to use it to setup CloudTrail logs for auditing. I've made a similar PR on your CloudTrail module as well.

I'm making this PR because in my project we have our own tag naming schema and that does not play well together with Cloud Posse's scheme. I understand if this change isn't really interesting for you, but I think it's a nice addition for people, like me, that want to use your modules without having extra tags being created on the resources.

I'm happy to accommodate any change you recommend, let me know.