### PR TITLE
Limit bucket name to 63 chars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "default_label" {
 
 resource "aws_s3_bucket" "default" {
   count         = var.enabled ? 1 : 0
-  bucket        = module.default_label.id
+  bucket        = substr(module.default_label.id, 0, 63)
   acl           = var.acl
   region        = var.region
   force_destroy = var.force_destroy


### PR DESCRIPTION
As per S3 specs, buckets cannot be more than 63 characters long