### PR TITLE
Add blocking of public access to the bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ It enables server-side default encryption.
 
 https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html
 
+It blocks public access to the bucket by default.
+
+https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
+
 
 ---
 
@@ -126,6 +130,8 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | acl | The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services | string | `log-delivery-write` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
+| block_public_acls | Set to `false` to disable the blocking of new public access lists on the bucket | bool | `true` | no |
+| block_public_policy | Set to `false` to disable the blocking of new public policies on the bucket | bool | `true` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enable_glacier_transition | Enables the transition to AWS Glacier which can cause unnecessary costs for huge amount of small files | bool | `true` | no |
 | enabled | Set to `false` to prevent the module from creating any resources | bool | `true` | no |
@@ -133,6 +139,7 @@ Available targets:
 | expiration_days | Number of days after which to expunge the objects | number | `90` | no |
 | force_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | bool | `false` | no |
 | glacier_transition_days | Number of days after which to move the data to the glacier storage tier | number | `60` | no |
+| ignore_public_acls | Set to `false` to disable the ignoring of public access lists on the bucket | bool | `true` | no |
 | kms_master_key_arn | The AWS KMS master key ARN used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse_algorithm is aws:kms | string | `` | no |
 | lifecycle_prefix | Prefix filter. Used to manage object lifecycle events | string | `` | no |
 | lifecycle_rule_enabled | Enable lifecycle events on this bucket | bool | `true` | no |
@@ -143,6 +150,7 @@ Available targets:
 | noncurrent_version_transition_days | Specifies when noncurrent object versions transitions | number | `30` | no |
 | policy | A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy | string | `` | no |
 | region | If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee | string | `` | no |
+| restrict_public_buckets | Set to `false` to disable the restricting of making the bucket public | bool | `true` | no |
 | sse_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | string | `AES256` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
 | standard_transition_days | Number of days to persist in the standard storage tier before moving to the infrequent access tier | number | `30` | no |
@@ -214,6 +222,10 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 ## Slack Community
 
 Join our [Open Source Community][slack] on Slack. It's **FREE** for everyone! Our "SweetOps" community is where you get to talk with others who share a similar vision for how to rollout and manage infrastructure. This is the best place to talk shop, ask questions, solicit feedback, and work together as a community to build totally *sweet* infrastructure.
+
+## Discourse Forums
+
+Participate in our [Discourse Forums][discourse]. Here you'll find answers to commonly asked questions. Most questions will be related to the enormous number of projects we support on our GitHub. Come here to collaborate on answers, find solutions, and get ideas about the products and services we value. It only takes a minute to get started! Just sign in with SSO using your GitHub account.
 
 ## Newsletter
 
@@ -330,6 +342,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [testimonial]: https://cpco.io/leave-testimonial?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-s3-log-storage&utm_content=testimonial
   [office_hours]: https://cloudposse.com/office-hours?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-s3-log-storage&utm_content=office_hours
   [newsletter]: https://cpco.io/newsletter?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-s3-log-storage&utm_content=newsletter
+  [discourse]: https://ask.sweetops.com/?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-s3-log-storage&utm_content=discourse
   [email]: https://cpco.io/email?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-s3-log-storage&utm_content=email
   [commercial_support]: https://cpco.io/commercial-support?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-s3-log-storage&utm_content=commercial_support
   [we_love_open_source]: https://cpco.io/we-love-open-source?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-s3-log-storage&utm_content=we_love_open_source

--- a/README.yaml
+++ b/README.yaml
@@ -74,6 +74,10 @@ description: |-
 
   https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html
 
+  It blocks public access to the bucket by default.
+
+  https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
+
 # How to use this project
 usage: |-
   ```hcl

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,6 +4,8 @@
 |------|-------------|:----:|:-----:|:-----:|
 | acl | The canned ACL to apply. We recommend log-delivery-write for compatibility with AWS services | string | `log-delivery-write` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | list(string) | `<list>` | no |
+| block_public_acls | Set to `false` to disable the blocking of new public access lists on the bucket | bool | `true` | no |
+| block_public_policy | Set to `false` to disable the blocking of new public policies on the bucket | bool | `true` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | enable_glacier_transition | Enables the transition to AWS Glacier which can cause unnecessary costs for huge amount of small files | bool | `true` | no |
 | enabled | Set to `false` to prevent the module from creating any resources | bool | `true` | no |
@@ -11,6 +13,7 @@
 | expiration_days | Number of days after which to expunge the objects | number | `90` | no |
 | force_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable | bool | `false` | no |
 | glacier_transition_days | Number of days after which to move the data to the glacier storage tier | number | `60` | no |
+| ignore_public_acls | Set to `false` to disable the ignoring of public access lists on the bucket | bool | `true` | no |
 | kms_master_key_arn | The AWS KMS master key ARN used for the SSE-KMS encryption. This can only be used when you set the value of sse_algorithm as aws:kms. The default aws/s3 AWS KMS master key is used if this element is absent while the sse_algorithm is aws:kms | string | `` | no |
 | lifecycle_prefix | Prefix filter. Used to manage object lifecycle events | string | `` | no |
 | lifecycle_rule_enabled | Enable lifecycle events on this bucket | bool | `true` | no |
@@ -21,6 +24,7 @@
 | noncurrent_version_transition_days | Specifies when noncurrent object versions transitions | number | `30` | no |
 | policy | A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy | string | `` | no |
 | region | If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee | string | `` | no |
+| restrict_public_buckets | Set to `false` to disable the restricting of making the bucket public | bool | `true` | no |
 | sse_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | string | `AES256` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
 | standard_transition_days | Number of days to persist in the standard storage tier before moving to the infrequent access tier | number | `30` | no |

--- a/main.tf
+++ b/main.tf
@@ -74,3 +74,15 @@ resource "aws_s3_bucket" "default" {
 
   tags = module.default_label.tags
 }
+
+# Refer to the terraform documentation on s3_bucket_public_access_block at
+# https://www.terraform.io/docs/providers/aws/r/s3_bucket_public_access_block.html
+# for the nuances of the blocking options
+resource "aws_s3_bucket_public_access_block" "default" {
+  bucket = join("", aws_s3_bucket.default.*.id)
+
+  block_public_acls       = var.block_public_acls
+  block_public_policy     = var.block_public_policy
+  ignore_public_acls      = var.ignore_public_acls
+  restrict_public_buckets = var.restrict_public_buckets
+}

--- a/variables.tf
+++ b/variables.tf
@@ -140,3 +140,27 @@ variable "enabled" {
   default     = true
   description = "Set to `false` to prevent the module from creating any resources"
 }
+
+variable "block_public_acls" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable the blocking of new public access lists on the bucket"
+}
+
+variable "block_public_policy" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable the blocking of new public policies on the bucket"
+}
+
+variable "ignore_public_acls" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable the ignoring of public access lists on the bucket"
+}
+
+variable "restrict_public_buckets" {
+  type        = bool
+  default     = true
+  description = "Set to `false` to disable the restricting of making the bucket public"
+}


### PR DESCRIPTION
This is a change to the current default behavior, where buckets will be left in a state where they could be made public, and instead makes the buckets block public access by default.