### PR TITLE
update aws providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,13 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.34, < 4.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 
@@ -119,7 +120,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.34, < 4.0 |
 
 ## Inputs
 
@@ -148,7 +149,6 @@ Available targets:
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent object versions expire | `number` | `90` | no |
 | noncurrent\_version\_transition\_days | Specifies when noncurrent object versions transitions | `number` | `30` | no |
 | policy | A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy | `string` | `""` | no |
-| region | If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee | `string` | `""` | no |
 | restrict\_public\_buckets | Set to `false` to disable the restricting of making the bucket public | `bool` | `true` | no |
 | sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"AES256"` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
@@ -166,6 +166,7 @@ Available targets:
 | enabled | Is module enabled |
 | prefix | Prefix configured for lifecycle rules |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,9 +1,10 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.34, < 4.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 
@@ -11,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.34, < 4.0 |
 
 ## Inputs
 
@@ -40,7 +41,6 @@
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent object versions expire | `number` | `90` | no |
 | noncurrent\_version\_transition\_days | Specifies when noncurrent object versions transitions | `number` | `30` | no |
 | policy | A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy | `string` | `""` | no |
-| region | If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee | `string` | `""` | no |
 | restrict\_public\_buckets | Set to `false` to disable the restricting of making the bucket public | `bool` | `true` | no |
 | sse\_algorithm | The server-side encryption algorithm to use. Valid values are AES256 and aws:kms | `string` | `"AES256"` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
@@ -58,3 +58,4 @@
 | enabled | Is module enabled |
 | prefix | Prefix configured for lifecycle rules |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,6 @@ resource "aws_s3_bucket" "default" {
   count         = var.enabled ? 1 : 0
   bucket        = module.default_label.id
   acl           = var.acl
-  region        = var.region
   force_destroy = var.force_destroy
   policy        = var.policy
 

--- a/variables.tf
+++ b/variables.tf
@@ -63,12 +63,6 @@ variable "lifecycle_tags" {
   default     = {}
 }
 
-variable "region" {
-  type        = string
-  description = "If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee"
-  default     = ""
-}
-
 variable "force_destroy" {
   type        = bool
   description = "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable"

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
+  required_version = ">= 0.12.0"
 
   required_providers {
-    aws   = ">= 2.0, < 4.0"
-    local = "~> 1.2"
-    null  = "~> 2.0"
+    aws   = ">= 2.0"
+    local = ">= 1.2"
+    null  = ">= 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 2.0"
+    aws      = ">= 2.34, < 4.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = ">= 2.34, < 4.0"
+    aws   = ">= 2.34, < 4.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = ">= 2.34, < 4.0"
+    aws   = ">= 2.0, < 4.0"
     local = "~> 1.2"
     null  = "~> 2.0"
   }


### PR DESCRIPTION
## what
* support aws 3.x provider

## why
* enable using with other modules requiring aws 3.x provider

## references
* requires 3.x: https://github.com/cloudposse/terraform-aws-ecr/blob/master/main.tf#L30
* fixes #37 
