### PR TITLE
fix: refactor following terraform-aws-provider 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,16 @@ Available targets:
 | Name | Type |
 |------|------|
 | [aws_s3_bucket.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_lifecycle_configuration.bucket_lifecycle_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_logging.bucket_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_ownership_controls.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.bucket_sse](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_sqs_queue.notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [time_sleep.wait_for_aws_s3_bucket_settings](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -328,7 +334,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -25,10 +25,16 @@
 | Name | Type |
 |------|------|
 | [aws_s3_bucket.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.bucket_acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_lifecycle_configuration.bucket_lifecycle_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_logging.bucket_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_notification.bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_notification) | resource |
 | [aws_s3_bucket_ownership_controls.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
+| [aws_s3_bucket_policy.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.bucket_sse](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.log_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_sqs_queue.notifications](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [time_sleep.wait_for_aws_s3_bucket_settings](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/main.tf
+++ b/main.tf
@@ -3,79 +3,107 @@ resource "aws_s3_bucket" "default" {
   #bridgecrew:skip=CKV_AWS_52:Skipping `Ensure S3 bucket has MFA delete enabled` due to issue in terraform (https://github.com/hashicorp/terraform-provider-aws/issues/629).
   count         = module.this.enabled ? 1 : 0
   bucket        = module.this.id
-  acl           = var.acl
   force_destroy = var.force_destroy
-  policy        = var.policy
-
-  versioning {
-    enabled    = var.versioning_enabled
-    mfa_delete = var.versioning_mfa_delete_enabled
-  }
-
-  // MFA Enabled is not compatable with lifecycle management - https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-and-other-bucket-config.html
-  dynamic "lifecycle_rule" {
-    for_each = var.versioning_mfa_delete_enabled ? [] : [1]
-    content {
-      id                                     = module.this.id
-      enabled                                = var.lifecycle_rule_enabled
-      prefix                                 = var.lifecycle_prefix
-      tags                                   = var.lifecycle_tags
-      abort_incomplete_multipart_upload_days = var.abort_incomplete_multipart_upload_days
-
-      noncurrent_version_expiration {
-        days = var.noncurrent_version_expiration_days
-      }
-
-      dynamic "noncurrent_version_transition" {
-        for_each = var.enable_glacier_transition ? [1] : []
-
-        content {
-          days          = var.noncurrent_version_transition_days
-          storage_class = "GLACIER"
-        }
-      }
-
-      transition {
-        days          = var.standard_transition_days
-        storage_class = "STANDARD_IA"
-      }
-
-      dynamic "transition" {
-        for_each = var.enable_glacier_transition ? [1] : []
-
-        content {
-          days          = var.glacier_transition_days
-          storage_class = "GLACIER"
-        }
-      }
-
-      expiration {
-        days = var.expiration_days
-      }
-
-    }
-  }
-
-  dynamic "logging" {
-    for_each = var.access_log_bucket_name != "" ? [1] : []
-    content {
-      target_bucket = var.access_log_bucket_name
-      target_prefix = "${var.access_log_bucket_prefix}${module.this.id}/"
-    }
-  }
-
-  # https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html
-  # https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#enable-default-server-side-encryption
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm     = var.sse_algorithm
-        kms_master_key_id = var.kms_master_key_arn
-      }
-    }
-  }
 
   tags = module.this.tags
+}
+
+resource "aws_s3_bucket_acl" "bucket_acl" {
+  count  = module.this.enabled ? 1 : 0
+  bucket = aws_s3_bucket.default[0].id
+  acl    = var.acl
+}
+
+resource "aws_s3_bucket_policy" "bucket_policy" {
+  count  = module.this.enabled ? 1 : 0
+  bucket = aws_s3_bucket.default[0].id
+  policy = var.policy
+}
+
+resource "aws_s3_bucket_versioning" "log_bucket" {
+  count  = module.this.enabled ? 1 : 0
+  bucket = aws_s3_bucket.default[0].id
+
+  versioning_configuration {
+    status     = var.versioning_enabled ? "Enabled" : "Suspended"
+    mfa_delete = var.versioning_mfa_delete_enabled ? "Enabled" : "Disabled"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "bucket_lifecycle_config" {
+  // MFA Enabled is not compatible with lifecycle management - https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-and-other-bucket-config.html
+  count = module.this.enabled && !var.versioning_mfa_delete_enabled ? 1 : 0
+
+  bucket = aws_s3_bucket.default[0].bucket
+
+  rule {
+    id     = module.this.id
+    status = var.lifecycle_rule_enabled ? "Enabled" : "Disabled"
+
+    filter {
+      and {
+        prefix = var.lifecycle_prefix
+        tags   = var.lifecycle_tags
+      }
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = var.abort_incomplete_multipart_upload_days
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.noncurrent_version_expiration_days
+    }
+
+    dynamic "noncurrent_version_transition" {
+      for_each = var.enable_glacier_transition ? [1] : []
+
+      content {
+        noncurrent_days = var.noncurrent_version_transition_days
+        storage_class   = "GLACIER"
+      }
+    }
+
+    transition {
+      days          = var.standard_transition_days
+      storage_class = "STANDARD_IA"
+    }
+
+    dynamic "transition" {
+      for_each = var.enable_glacier_transition ? [1] : []
+
+      content {
+        days          = var.glacier_transition_days
+        storage_class = "GLACIER"
+      }
+    }
+
+    expiration {
+      days = var.expiration_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_logging" "bucket_logging" {
+  count  = module.this.enabled && var.access_log_bucket_name != "" ? 1 : 0
+  bucket = aws_s3_bucket.default[0].id
+
+  target_bucket = var.access_log_bucket_name
+  target_prefix = "${var.access_log_bucket_prefix}${module.this.id}/"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "bucket_sse" {
+  count = module.this.enabled ? 1 : 0
+  # https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html
+  # https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#enable-default-server-side-encryption
+  bucket = aws_s3_bucket.default[0].id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = var.sse_algorithm
+      kms_master_key_id = var.kms_master_key_arn
+    }
+  }
 }
 
 data "aws_iam_policy_document" "bucket_policy" {
@@ -154,9 +182,9 @@ data "aws_iam_policy_document" "bucket_policy" {
 data "aws_partition" "current" {}
 
 data "aws_iam_policy_document" "aggregated_policy" {
-  count         = module.this.enabled ? 1 : 0
-  source_json   = var.policy
-  override_json = join("", data.aws_iam_policy_document.bucket_policy.*.json)
+  count                     = module.this.enabled ? 1 : 0
+  source_policy_documents   = [var.policy]
+  override_policy_documents = data.aws_iam_policy_document.bucket_policy.*.json
 }
 
 resource "aws_s3_bucket_policy" "default" {
@@ -180,8 +208,8 @@ resource "aws_s3_bucket_public_access_block" "default" {
 }
 
 # Per https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html
-# It is safe to always set to BucketOwnerPreferred. The bucket owner will own the object 
-# if the object is uploaded with the bucket-owner-full-control canned ACL. Without 
+# It is safe to always set to BucketOwnerPreferred. The bucket owner will own the object
+# if the object is uploaded with the bucket-owner-full-control canned ACL. Without
 # this setting and canned ACL, the object is uploaded and remains owned by the uploading account.
 resource "aws_s3_bucket_ownership_controls" "default" {
   count  = module.this.enabled ? 1 : 0

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "aws_s3_bucket_versioning" "log_bucket" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "bucket_lifecycle_config" {
   // MFA Enabled is not compatible with lifecycle management - https://docs.aws.amazon.com/AmazonS3/latest/userguide/lifecycle-and-other-bucket-config.html
-  count = module.this.enabled && !var.versioning_mfa_delete_enabled ? 1 : 0
+  count = module.this.enabled && ! var.versioning_mfa_delete_enabled ? 1 : 0
 
   bucket = aws_s3_bucket.default[0].bucket
 


### PR DESCRIPTION
## what
- replace `acl`, `policy`, `versioning`, `lifecycle_rule`, `logging` and `server_side_encryption_configuration` arguments with their  corresponding resources;
- update deprecated arguments in `aws_iam_policy_document`.

## why
- `terraform-provider-aws` version 4.0.0 have deprecated a series of arguments on the `aws_s3_bucket` resource;
- this should result in no functional changes.

## references
- provider release notes for [4.0.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v4.0.0).

**Note**: this is very much a WIP; there are a couple of things which don't quite seem to marry up:
- if versioning is enabled on the `aws_s3_bucket_versioning` resource, `mfa` is [required](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning#mfa)—this seemingly wasn't the case on the old `versioning` argument, nor am I entirely sure how this could reasonably be achieved;
- how to move the [`filter`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#filter) argument to a `aws_s3_bucket_lifecycle_configuration` resource and corresponding [`filter`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#filter) argument isn't entirely clear.
- and, of course, most analysis tools won't work against the new structure, e.g.:
  - `checkov` tracking their changes [here](https://github.com/bridgecrewio/checkov/issues/2399);
  - `tfsec` tracking their changes [here](https://github.com/aquasecurity/tfsec/issues/1532).