### PR TITLE
Cleanups and safety checks for upgrade

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,3 @@
 {
-  "extends": [
-    "config:base",
-    ":preserveSemverRanges"
-  ],
-  "labels": ["auto-update"],
-  "enabledManagers": [],
-  "terraform": {
-    "ignorePaths": ["**/context.tf", "examples/**"]
-  }
+  "enabled": false
 }
-

--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@
 
 This module creates an S3 bucket suitable for receiving logs from other `AWS` services such as `S3`, `CloudFront`, and `CloudTrails`.
 
-It implements a configurable log retention policy, which allows you to efficiently manage logs across different storage classes (_e.g._ `Glacier`) and ultimately expire the data altogether.
+**WARNING:** Changes introduced in version 0.27.0 present a **HIGH RISK OF DATA LOSS** when upgrading from an
+earlier version. This warning does not apply to new deployments created with version 0.28.0 or later, but 
+if upgrading from an earlier version, please follow the 
+[upgrade instructions](https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.27.0-(POTENTIAL-DATA-LOSS))
+in this repo's Wiki.
+
+This module implements a configurable log retention policy, which allows you to efficiently manage logs across different storage classes (_e.g._ `Glacier`) and ultimately expire the data altogether.
 
 It enables server-side default encryption.
 
@@ -39,6 +45,11 @@ https://docs.aws.amazon.com/AmazonS3/latest/dev/bucket-encryption.html
 It blocks public access to the bucket by default.
 
 https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
+
+As of March, 2022, this module is primarily a wrapper around our 
+[s3-bucket](https://github.com/cloudposse/terraform-aws-s3-bucket)
+module, with some options preconfigured and SQS notifications added. If it does not exactly suit your needs,
+you may want to use the `s3-bucket` module directly.
 
 ---
 
@@ -103,6 +114,14 @@ the registry shows many of our inputs as required when in fact they are optional
 The table below correctly indicates which inputs are required.
 
 
+
+**WARNING:** Changes introduced in version 0.27.0 present a **HIGH RISK OF DATA LOSS** when upgrading from an
+earlier version. This warning does not apply to new deployments created with version 0.28.0 or later, but 
+if upgrading from an earlier version, please follow the 
+[upgrade instructions](https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.27.0-(POTENTIAL-DATA-LOSS))
+in this repo's Wiki.
+
+
 ```hcl
 module "log_storage" {
   source = "cloudposse/s3-log-storage/aws"
@@ -154,7 +173,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_s3_bucket"></a> [aws\_s3\_bucket](#module\_aws\_s3\_bucket) | cloudposse/s3-bucket/aws | 0.47.0 |
+| <a name="module_aws_s3_bucket"></a> [aws\_s3\_bucket](#module\_aws\_s3\_bucket) | cloudposse/s3-bucket/aws | 0.47.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -244,6 +263,7 @@ Are you using this project or any of our other projects? Consider [leaving a tes
 
 Check out these related projects.
 
+- [terraform-aws-s3-bucket](https://github.com/cloudposse/terraform-aws-s3-bucket) - Terraform module that creates an S3 bucket with an optional IAM user for external CI/CD systems
 - [terraform-aws-cloudfront-s3-cdn](https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn) - Terraform module to easily provision CloudFront CDN backed by an S3 origin
 - [terraform-aws-s3-website](https://github.com/cloudposse/terraform-aws-s3-website) - Terraform Module for Creating S3 backed Websites and Route53 DNS
 - [terraform-aws-user-data-s3-backend](https://github.com/cloudposse/terraform-aws-user-data-s3-backend) - Terraform Module to Offload User Data to S3

--- a/README.yaml
+++ b/README.yaml
@@ -24,6 +24,9 @@ badges:
   image: https://slack.cloudposse.com/badge.svg
   url: https://slack.cloudposse.com
 related:
+- name: terraform-aws-s3-bucket
+  description:  Terraform module that creates an S3 bucket with an optional IAM user for external CI/CD systems
+  url: https://github.com/cloudposse/terraform-aws-s3-bucket
 - name: terraform-aws-cloudfront-s3-cdn
   description: Terraform module to easily provision CloudFront CDN backed by an S3
     origin
@@ -45,7 +48,13 @@ related:
 description: |-
   This module creates an S3 bucket suitable for receiving logs from other `AWS` services such as `S3`, `CloudFront`, and `CloudTrails`.
 
-  It implements a configurable log retention policy, which allows you to efficiently manage logs across different storage classes (_e.g._ `Glacier`) and ultimately expire the data altogether.
+  **WARNING:** Changes introduced in version 0.27.0 present a **HIGH RISK OF DATA LOSS** when upgrading from an
+  earlier version. This warning does not apply to new deployments created with version 0.28.0 or later, but 
+  if upgrading from an earlier version, please follow the 
+  [upgrade instructions](https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.27.0-(POTENTIAL-DATA-LOSS))
+  in this repo's Wiki.
+  
+  This module implements a configurable log retention policy, which allows you to efficiently manage logs across different storage classes (_e.g._ `Glacier`) and ultimately expire the data altogether.
 
   It enables server-side default encryption.
 
@@ -54,7 +63,21 @@ description: |-
   It blocks public access to the bucket by default.
 
   https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
+  
+  As of March, 2022, this module is primarily a wrapper around our 
+  [s3-bucket](https://github.com/cloudposse/terraform-aws-s3-bucket)
+  module, with some options preconfigured and SQS notifications added. If it does not exactly suit your needs,
+  you may want to use the `s3-bucket` module directly.
+
 usage: |-
+  
+  **WARNING:** Changes introduced in version 0.27.0 present a **HIGH RISK OF DATA LOSS** when upgrading from an
+  earlier version. This warning does not apply to new deployments created with version 0.28.0 or later, but 
+  if upgrading from an earlier version, please follow the 
+  [upgrade instructions](https://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.27.0-(POTENTIAL-DATA-LOSS))
+  in this repo's Wiki.
+  
+  
   ```hcl
   module "log_storage" {
     source = "cloudposse/s3-log-storage/aws"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,7 +17,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_s3_bucket"></a> [aws\_s3\_bucket](#module\_aws\_s3\_bucket) | cloudposse/s3-bucket/aws | 0.47.0 |
+| <a name="module_aws_s3_bucket"></a> [aws\_s3\_bucket](#module\_aws\_s3\_bucket) | cloudposse/s3-bucket/aws | 0.47.1 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "s3_log_storage" {
   source        = "../../"
-  force_destroy = true
+  force_destroy = false
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -47,7 +47,7 @@ moved {
 
 module "aws_s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
-  version = "0.47.0"
+  version = "0.47.1"
 
   bucket_name        = module.this.id
   acl                = var.acl
@@ -55,7 +55,8 @@ module "aws_s3_bucket" {
   policy             = var.policy
   versioning_enabled = var.versioning_enabled
 
-  lifecycle_rules = [local.lifecycle_rule]
+  lifecycle_rule_ids = [module.this.id]
+  lifecycle_rules    = [local.lifecycle_rule]
 
   logging = var.access_log_bucket_name == "" ? null : {
     bucket_name = var.access_log_bucket_name

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,12 @@ variable "force_destroy" {
   type        = bool
   description = "(Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable"
   default     = false
+  validation {
+    condition = (var.force_destroy == false)
+    # Error messages must be written on a single line.
+    # See https://github.com/hashicorp/terraform/issues/24123
+    error_message = "Because of the HIGH RISK OF DATA LOSS when using this version of this module, force_destroy must be set to false.\n\nWARNING: If you applied a previous version of the module with force_destroy set to true,\nsimply setting it to false here will NOT protect your data. You must set it false and apply\nthe previous version first in order to safeguard your data. See the Wiki entry at\nhttps://github.com/cloudposse/terraform-aws-s3-log-storage/wiki/Upgrading-to-v0.27.0-(POTENTIAL-DATA-LOSS)\nfor more details."
+  }
 }
 
 variable "lifecycle_rule_enabled" {


### PR DESCRIPTION
## what
- Add warning to README and error when `force_destroy` is `true`
- Maintain rule name for lifecycle rule
- Disable Renovate bot

## why
- If `force_destroy` is `true` then an automated, unattended process could cause the S3 bucket to be deleted and all data in it irretrievably lost
- Remove an unwanted and unneeded source of changes created by upgrading
- This version should not be updated, it is pinned for compability

## references

Closes Renovate PRs:
- Closes #67 (do not want)
- Closes #68 (incorporated via `build-harness`)
- Closes #69 (do not want)