### PR TITLE
Issue-122/Values expect list of strings vs string

### DIFF
--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -3,12 +3,6 @@ variable "region" {
   description = "AWS region"
 }
 
-variable "allow_ssl_requests_only" {
-  type        = bool
-  default     = true
-  description = "Set to `true` to require requests to use Secure Socket Layer (HTTPS/SSL). This will explicitly deny access to HTTP requests"
-}
-
 variable "lifecycle_configuration_rules" {
   type = list(object({
     enabled = bool

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,5 +1,6 @@
 variable "region" {
-  type = string
+  type        = string
+  description = "AWS region"
 }
 
 variable "allow_ssl_requests_only" {

--- a/sqs_notifications.tf
+++ b/sqs_notifications.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "sqs_policy" {
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
-      values   = module.aws_s3_bucket.bucket_arn
+      values   = [join("", module.aws_s3_bucket.bucket_arn)]
     }
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
## what
Updating the sqs iam permissions, as the values expects to be a list of strings vs just the single string arn that is the output of the module.

## why

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#condition-1 expects to be a list of strings, vs just the single string arn of the s3 bucket.

## references

Github issue #122 