### PR TITLE
Wrong valuess for one, and missing the other one.

### DIFF
--- a/sqs_notifications.tf
+++ b/sqs_notifications.tf
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "sqs_policy" {
     condition {
       test     = "ArnEquals"
       variable = "aws:SourceArn"
-      values   = module.aws_s3_bucket.bucket_arn
+      values   = [module.aws_s3_bucket.bucket_arn]
     }
     condition {
       test     = "StringEquals"
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "sqs_policy" {
 
 resource "aws_s3_bucket_notification" "bucket_notification" {
   count  = local.sqs_notifications_enabled ? 1 : 0
-  bucket = join("", module.aws_s3_bucket.bucket_id)
+  bucket = module.aws_s3_bucket.bucket_id
 
   queue {
     queue_arn = join("", aws_sqs_queue.notifications[*].arn)


### PR DESCRIPTION
## what

- Initially put the wrong values for coditions, just needs to be a list
- Bucket should be single resource vs joining on a list.

## references
issue `#122`

