### PR TITLE
chore: bump s3-bucket dependency to v4.12.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,7 @@ module "bucket_name" {
 
 module "aws_s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
-  version = "4.10.0"
+  version = "4.12.0"
 
   bucket_name        = local.bucket_name
   acl                = var.acl
@@ -37,9 +37,10 @@ module "aws_s3_bucket" {
     prefix      = "${var.access_log_bucket_prefix}${local.bucket_name}/"
   }]
 
-  sse_algorithm      = var.sse_algorithm
-  kms_master_key_arn = var.kms_master_key_arn
-  bucket_key_enabled = var.bucket_key_enabled
+  sse_algorithm            = var.sse_algorithm
+  kms_master_key_arn       = var.kms_master_key_arn
+  bucket_key_enabled       = var.bucket_key_enabled
+  blocked_encryption_types = var.blocked_encryption_types
 
   allow_encrypted_uploads_only = var.allow_encrypted_uploads_only
   allow_ssl_requests_only      = var.allow_ssl_requests_only

--- a/variables.tf
+++ b/variables.tf
@@ -107,6 +107,16 @@ variable "bucket_key_enabled" {
   nullable    = false
 }
 
+variable "blocked_encryption_types" {
+  type        = list(string)
+  description = <<-EOT
+  List of encryption types to block for the S3 bucket. Set to `["NONE"]` on
+  AWS provider >= 6.22.0 to prevent perpetual SSE configuration drift.
+  Defaults to `null` (omitted) for backward compatibility with older providers.
+  EOT
+  default     = null
+}
+
 variable "block_public_acls" {
   type        = bool
   description = "Set to `false` to disable the blocking of new public access lists on the bucket"


### PR DESCRIPTION
## what
Bumps `cloudposse/s3-bucket/aws` from v4.10.0 to v4.12.0.

## why
Fixes #135.

v4.12.0 adds `blocked_encryption_types` support (cloudposse/terraform-aws-s3-bucket#289), which fixes perpetual SSE encryption drift on AWS provider >= 6.22.0. Without this bump, `s3-log-storage` users see plan diffs on every run where Terraform tries to remove `blocked_encryption_types = ["NONE"]` from the encryption rule.